### PR TITLE
pass access token with quotes data GET request via self.headers

### DIFF
--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -230,11 +230,11 @@ class Robinhood:
 
         #Check for validity of symbol
         try:
-            req = requests.get(url, timeout=15)
+            req = requests.get(url, headers=self.headers, timeout=15)
             req.raise_for_status()
             data = req.json()
         except requests.exceptions.HTTPError:
-            raise RH_exception.InvalidTickerSymbol()
+            raise RH_exception.RobinhoodException()
 
 
         return data
@@ -255,11 +255,11 @@ class Robinhood:
         url = str(endpoints.quotes()) + "?symbols=" + ",".join(stocks)
 
         try:
-            req = requests.get(url, timeout=15)
+            req = requests.get(url, headers=self.headers, timeout=15)
             req.raise_for_status()
             data = req.json()
         except requests.exceptions.HTTPError:
-            raise RH_exception.InvalidTickerSymbol()
+            raise RH_exception.RobinhoodException()
 
 
         return data["results"]


### PR DESCRIPTION
This PR adds code to pass `self.headers` with the GET requests inside functions `quote_data` and `quotes_data` in order to fix a recent update to RH API per #167 

Also, the PR replaces the `InvalidTickerSymbol` exception with the generic `RobinhoodException` in order to more accurately reflect the range of errors that could occur. 

