### PR TITLE
fixed get_quote_list

### DIFF
--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -154,7 +154,7 @@ class Robinhood(SessionManager):
             keys = key.split(",")
             myStr = ""
             for item in keys:
-                myStr += stock[item] + ","
+                myStr += f"{stock[item]},"
 
             return myStr.split(",")
 


### PR DESCRIPTION

# Error:
```
myStr += stock[item] + ","
TypeError: unsupported operand type(s) for +: 'int' and 'str'
```
 
# Fix:

```
myStr += f"{stock[item]},"
```
