### PR TITLE
fix: updated historicals url build #229

### DIFF
--- a/newsfragments/229.bugfix
+++ b/newsfragments/229.bugfix
@@ -1,0 +1,1 @@
+Updated the .get_historical_quotes() to use the URL method .with_query() in order to build a URL with params.

--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -185,17 +185,12 @@ class Robinhood(InstrumentManager, SessionManager):
         if isinstance(bounds, str):  # recast to Enum
             bounds = Bounds(bounds)
 
-        historicals = (
-            urls.HISTORICALS
-            + "/?symbols="
-            + ",".join(stock).upper()
-            + "&interval="
-            + interval
-            + "&span="
-            + span
-            + "&bounds="
-            + bounds.name.lower()
-        )
+        historicals = (urls.HISTORICALS.with_query([
+            ('symbols', ",".join(stock).upper()),
+            ('interval', interval),
+            ('span', span),
+            ('bounds', bounds.name.lower())
+        ]))
 
         return self.get(historicals)
 

--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -185,12 +185,14 @@ class Robinhood(InstrumentManager, SessionManager):
         if isinstance(bounds, str):  # recast to Enum
             bounds = Bounds(bounds)
 
-        historicals = (urls.HISTORICALS.with_query([
-            ('symbols', ",".join(stock).upper()),
-            ('interval', interval),
-            ('span', span),
-            ('bounds', bounds.name.lower())
-        ]))
+        historicals = urls.HISTORICALS.with_query(
+            [
+                ('symbols', ",".join(stock).upper()),
+                ('interval', interval),
+                ('span', span),
+                ('bounds', bounds.name.lower())
+            ]
+        )
 
         return self.get(historicals)
 

--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -187,10 +187,10 @@ class Robinhood(InstrumentManager, SessionManager):
 
         historicals = urls.HISTORICALS.with_query(
             [
-                ('symbols', ",".join(stock).upper()),
-                ('interval', interval),
-                ('span', span),
-                ('bounds', bounds.name.lower())
+                ("symbols", ",".join(stock).upper()),
+                ("interval", interval),
+                ("span", span),
+                ("bounds", bounds.name.lower()),
             ]
         )
 


### PR DESCRIPTION
<!--
Thanks you for taking the time to submit a pull request! Please take a look at some
guidelines before submitting a pull request:
https://github.com/robinhood-unofficial/pyrh/blob/master/doc/developers.rst

Below are some gentle reminder about common mistakes before PR submission. Please make sure that you tick
all *appropriate* boxes.
-->

#### Checklist
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
- [x] I've added a news fragment of my changes with the name,
  "{ISSUE_NUM}.{feature|bugfix|doc|removal|misc}""


# Related Issue
Fixes: #229 

# Description
Using `get_historical_quotes` yields an error given the way a `URL` is being concatenated with a `str`. Updated the code to use the `URL` method `.with_query` in order to build a URL with params.