### PR TITLE
prompt for user/pass when logging in

### DIFF
--- a/pyrh/models/sessionmanager.py
+++ b/pyrh/models/sessionmanager.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import datetime, timedelta
+from getpass import getpass
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
 from urllib.request import getproxies
 
@@ -101,8 +102,8 @@ class SessionManager(BaseModel):
 
     def __init__(
         self,
-        username: str,
-        password: str,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
         challenge_type: Optional[str] = "email",
         headers: Optional[CaseInsensitiveDictType] = None,
         proxies: Optional[Proxies] = None,
@@ -116,8 +117,8 @@ class SessionManager(BaseModel):
             tzinfo=pytz.UTC
         )  # some time in the past
 
-        self.username: str = username
-        self.password: str = password
+        self.username: Optional[str] = username
+        self.password: Optional[str] = password
         if challenge_type not in ["email", "sms"]:
             raise ValueError("challenge_type must be email or sms")
         self.challenge_type: str = challenge_type
@@ -165,6 +166,10 @@ class SessionManager(BaseModel):
                 refresh.
 
         """
+        if not self.login_set:
+            self.username = input("Please enter username:")
+            self.password = getpass(prompt="Password:")
+
         if "Authorization" not in self.session.headers:
             self._login_oauth2()
         elif self.oauth.is_valid and (self.token_expired or force_refresh):


### PR DESCRIPTION
<!--
Thanks you for taking the time to submit a pull request! Please take a look at some
guidelines before submitting a pull request:
https://github.com/robinhood-unofficial/pyrh/blob/master/doc/developers.rst

Below are some gentle reminder about common mistakes before PR submission. Please make sure that you tick
all *appropriate* boxes.
-->

#### Checklist
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
- [ ] I've added a news fragment of my changes with the name,
  "{ISSUE_NUM}.{feature|bugfix|doc|removal|misc}""


# Related Issue
<!--
Example: Fixes #7. See also #35.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

# Description
Instead of forcing user to enter username/password when initializing Robinhood obj, set it as optional and prompt the user for it when they are trying to log in and they did not originally pass it in
