### PR TITLE
bug fix securities_owned()

### DIFF
--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -651,7 +651,7 @@ class Robinhood(InstrumentManager, SessionManager):
 
         """
 
-        return self.get(urls.POSITIONS + "?nonzero=true")
+        return self.get(str(urls.POSITIONS) + "?nonzero=true")
 
     ###########################################################################
     #                               PLACE ORDER


### PR DESCRIPTION
<!--
Thanks you for taking the time to submit a pull request! Please take a look at some
guidelines before submitting a pull request:
https://github.com/robinhood-unofficial/pyrh/blob/master/doc/developers.rst

Below are some gentle reminder about common mistakes before PR submission. Please make sure that you tick
all *appropriate* boxes.
-->

#### Checklist
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
- [ ] I've added a news fragment of my changes with the name,
  "{ISSUE_NUM}.{feature|bugfix|doc|removal|misc}""


# Related Issue
<!--
Example: Fixes #7. See also #35.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

# Description
<!--
Please add a narrative description of your the changes made and the rationale behind
them. If making an enhancement include the motivation and use cases addressed.
-->
calling  securities_owned() failed.

urls.POSITIONS + "?nonzero=true" did not work without converting urls.POSITIONS to a string first.

Another way would be to solve this is urls.POSITIONS.with_query("nonzero=true")
