### PR TITLE
Clear password after authentication and add username / pass prompt

### DIFF
--- a/newsfragments/255.feature
+++ b/newsfragments/255.feature
@@ -1,0 +1,1 @@
+Clear password after authentication and add username / pass prompt


### PR DESCRIPTION
Allow no username nor password to be passed to constructor. In this
case, user will be prompted for it on login() call.

<!--
Thanks you for taking the time to submit a pull request! Please take a look at some
guidelines before submitting a pull request:
https://github.com/robinhood-unofficial/pyrh/blob/master/doc/developers.rst

Below are some gentle reminder about common mistakes before PR submission. Please make sure that you tick
all *appropriate* boxes.
-->

#### Checklist
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
- [x] I've added a news fragment of my changes with the name,
  "{ISSUE_NUM}.{feature|bugfix|doc|removal|misc}""


# Description
- Clear "password" property from SessionManager after login is successful. This prevents us from saving the password on disk in cleartext, and keeping the password in memory after we have successfully performed the oauth authentication does not appear to be needed.
- Allow Robinhood() call without username and password, prompt user for both fields when login() is called if not previously set.
<!--
Please add a narrative description of your the changes made and the rationale behind
them. If making an enhancement include the motivation and use cases addressed.
-->
