### PR TITLE
Update robinhood.get_quote_list to handle lists of tickers fix #253

### DIFF
--- a/newsfragments/256.bugfix
+++ b/newsfragments/256.bugfix
@@ -1,0 +1,1 @@
+Update robinhood.get_quote_list to handle lists of tickers, fix #253

--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -122,28 +122,29 @@ class Robinhood(InstrumentManager, SessionManager):
 
         # Creates a tuple containing the information we want to retrieve
         def append_stock(stock):
-            keys = key.split(",")
-            myStr = ""
+            keys = key.split(",") if len(key) > 0 else stock.keys()
+            res = []
             for item in keys:
-                myStr += f"{stock[item]},"
+                res.append(f"{stock[item]}")
 
-            return myStr.split(",")
+            return res
 
         # Prompt for stock if not entered
         if not stock:  # pragma: no cover
             stock = input("Symbol: ")
 
-        data = self.quote_data(stock)
         res = []
 
         # Handles the case of multple tickers
         if stock.find(",") != -1:
-            for stock in data["results"]:
-                if stock is None:
+            for ticker in stock.split(","):
+                data = self.quote_data(ticker)
+                if data is None:
                     continue
-                res.append(append_stock(stock))
+                res.append(append_stock(data))
 
         else:
+            data = self.quote_data(stock)
             res.append(append_stock(data))
 
         return res


### PR DESCRIPTION
<!--
Thanks you for taking the time to submit a pull request! Please take a look at some
guidelines before submitting a pull request:
https://github.com/robinhood-unofficial/pyrh/blob/master/doc/developers.rst

Below are some gentle reminder about common mistakes before PR submission. Please make sure that you tick
all *appropriate* boxes.
-->

#### Checklist
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
- [ ] I've added a news fragment of my changes with the name,
  "{ISSUE_NUM}.{feature|bugfix|doc|removal|misc}""


# Related Issue
Fixes #253 


# Description
Update robinhood.get_quote_list to handle lists of tickers.
Update robinhood.get_quote_list to handle empty keys argument, in which case we return all keys.
