### PR TITLE
resolve ValueError exception encountered in urls.py 'build_chain' function

### DIFF
--- a/pyrh/urls.py
+++ b/pyrh/urls.py
@@ -172,7 +172,7 @@ def build_chain(instrument_id: str) -> URL:
 
     """
     return (
-        OPTIONS_CHAIN_BASE.with_query(equity_instrument_ids=f"{instrument_id}") / "/"
+        OPTIONS_CHAIN_BASE.with_query(equity_instrument_ids=f"{instrument_id}")
     )  # TODO: find out if this trailing slash is required.
 
 


### PR DESCRIPTION
The trailing slash '/' causes an exception to be encountered in the 'yarl' library.

Fix for #258 