### PR TITLE
resolve 'AttributeError' exception in 'get_options()'

### DIFF
--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -499,7 +499,7 @@ class Robinhood(InstrumentManager, SessionManager):
         return [
             contract
             for contract in self.get_url(
-                urls.options(chain_id, _expiration_dates_string, option_type)
+                urls.build_options(chain_id, _expiration_dates_string, option_type)
             )["results"]
         ]
 


### PR DESCRIPTION
fix issue #260

<!--
Thanks you for taking the time to submit a pull request! Please take a look at some
guidelines before submitting a pull request:
https://github.com/robinhood-unofficial/pyrh/blob/master/doc/developers.rst

Below are some gentle reminder about common mistakes before PR submission. Please make sure that you tick
all *appropriate* boxes.
-->

#### Checklist
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
- [ ] I've added a news fragment of my changes with the name,
  "{ISSUE_NUM}.{feature|bugfix|doc|removal|misc}""


# Related Issue

fix for issue #260

# Description

Use correct name 'build_options' for function in urls.py