### PR TITLE
added ability to get ach transfer history

### DIFF
--- a/docs/stubs/pyrh.Robinhood.rst
+++ b/docs/stubs/pyrh.Robinhood.rst
@@ -14,6 +14,7 @@ pyrh.Robinhood
    .. autosummary::
 
       ~Robinhood.__init__
+      ~Robinhood.ach_transfers
       ~Robinhood.adjusted_previous_close
       ~Robinhood.ask_price
       ~Robinhood.ask_size

--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -629,6 +629,16 @@ class Robinhood(InstrumentManager, SessionManager):
 
         return self.get(urls.DIVIDENDS)
 
+    def ach_transfers(self):
+        """Wrapper to get ach transfers history
+
+        Returns:
+            (:obj: `dict`): JSON dict from getting ach transfer history
+
+        """
+
+        return self.get(urls.build_ach('transfers'))
+
     ###########################################################################
     #                           POSITIONS DATA
     ###########################################################################


### PR DESCRIPTION

# Description
For those who, in addition to pulling thair order and dividend history, would like to pull their cash transfer history, I have added a method "ach_transfers". This method calls the "urls.build_ach" function already made. Updated Docs (I think lol).
