### PR TITLE
Type cast YARL URL to String to support concatenation

### DIFF
--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -651,7 +651,7 @@ class Robinhood(InstrumentManager, SessionManager):
 
         """
 
-        return self.get(urls.POSITIONS + "?nonzero=true")
+        return self.get(str(urls.POSITIONS) + "?nonzero=true")
 
     ###########################################################################
     #                               PLACE ORDER


### PR DESCRIPTION
Fixes #268 by type casting YARL.URL to str.  

Bug was due to YARL library of type URL trying to concentrate the custom type to a string.  
