### PR TITLE
cast URL to string to allow for concatenation in cancel_order

### DIFF
--- a/newsfragments/281.bugfix
+++ b/newsfragments/281.bugfix
@@ -1,0 +1,1 @@
+Add str casts to URLs to allow concatenation in cancel_order function.

--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -1472,7 +1472,7 @@ class Robinhood(InstrumentManager, SessionManager):
         """
         if isinstance(order_id, str):
             try:
-                order = self.get(urls.build_orders() + order_id)
+                order = self.get(str(urls.build_orders()) + order_id)
             except (requests.exceptions.HTTPError) as err_msg:
                 raise ValueError(
                     "Failed to get Order for ID: "
@@ -1503,7 +1503,7 @@ class Robinhood(InstrumentManager, SessionManager):
         elif isinstance(order_id, dict):
             order_id = order_id["id"]
             try:
-                order = self.get(urls.build_orders() + order_id)
+                order = self.get(str(urls.build_orders()) + order_id)
             except (requests.exceptions.HTTPError) as err_msg:
                 raise ValueError(
                     "Failed to get Order for ID: "


### PR DESCRIPTION
<!--
Thanks you for taking the time to submit a pull request! Please take a look at some
guidelines before submitting a pull request:
https://github.com/robinhood-unofficial/pyrh/blob/master/doc/developers.rst

Below are some gentle reminder about common mistakes before PR submission. Please make sure that you tick
all *appropriate* boxes.
-->

#### Checklist
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
- [x] I've added a news fragment of my changes with the name,
  "{ISSUE_NUM}.{feature|bugfix|doc|removal|misc}""


# Related Issue
<!--
Example: Fixes #7. See also #35.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #280 

# Description
<!--
Please add a narrative description of your the changes made and the rationale behind
them. If making an enhancement include the motivation and use cases addressed.
-->
Add str casts to URLs to allow concatenation in cancel_order function.
