### PR TITLE
Update authentication to allow email/password auth without 2fa. Add cryptocurrency market orders.

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -11,6 +11,8 @@ Installation
 ************
 * Python 3.7+ is required
 * |poetry|_ is used to manage package dependencies
+* To use poetry with pycharm, set your python interpreter to the your path found by running ``poetry env info``
+
 * |pre-commit|_ is used to manage the project's tooling and linting
 
    * |black|_

--- a/pyrh/exceptions.py
+++ b/pyrh/exceptions.py
@@ -35,6 +35,12 @@ class InvalidTickerSymbol(PyrhException):
     pass
 
 
+class InvalidCryptoId(PyrhException):
+    """When an invalid cyptocurrency Id is given/"""
+
+    pass
+
+
 class InvalidOptionId(PyrhException):
     """When an invalid option id is given/"""
 

--- a/pyrh/models/oauth.py
+++ b/pyrh/models/oauth.py
@@ -8,7 +8,7 @@ from marshmallow import fields, validate
 from .base import BaseModel, BaseSchema
 
 
-CHALLENGE_TYPE_VAL = validate.OneOf(["email", "sms"])
+CHALLENGE_TYPE_VAL = validate.OneOf(["email", "sms", "null", "none"])
 
 
 class Challenge(BaseModel):
@@ -88,6 +88,19 @@ class OAuthSchema(BaseSchema):
 
     detail = fields.Str()
     challenge = fields.Nested(ChallengeSchema)
+    mfa_required = fields.Boolean()
+
+    access_token = fields.Str()
+    refresh_token = fields.Str()
+    expires_in = fields.Int()
+
+
+class OAuthSchemaWithoutChallenge(BaseSchema):
+    """The OAuth response schema."""
+
+    __model__ = OAuth
+
+    detail = fields.Str()
     mfa_required = fields.Boolean()
 
     access_token = fields.Str()

--- a/pyrh/models/sessionmanager.py
+++ b/pyrh/models/sessionmanager.py
@@ -47,7 +47,7 @@ HEADERS: CaseInsensitiveDictType = CaseInsensitiveDict(
 """Headers used when performing requests with robinhood api."""
 # 8.5 days (you have a small window to refresh after this)
 # I would refresh the token proactively every day in a script
-EXPIRATION_TIME: int = 734000
+EXPIRATION_TIME: int = 538020
 """Default expiration time for requests."""
 
 TIMEOUT: int = 1
@@ -77,7 +77,7 @@ class SessionManager(BaseModel):
     Args:
         username: The username to login to Robinhood.
         password: The password to login to Robinhood.
-        challenge_type: Either sms or email. (only if not using mfa)
+        challenge_type: Either sms, email, or none. (only if not using mfa)
         headers: Any optional header dict modifications for the session.
         proxies: Any optional proxy dict modification for the session.
         **kwargs: Any other passed parameters as converted to instance attributes.
@@ -93,7 +93,7 @@ class SessionManager(BaseModel):
             required.
         username: The username to login to Robinhood.
         password: The password to login to Robinhood.
-        challenge_type: Either sms or email. (only if not using mfa)
+        challenge_type: Either sms, email or none. (only if not using mfa)
         headers: Any optional header dict modifications for the session.
         proxies: Any optional proxy dict modification for the session.
 
@@ -103,7 +103,7 @@ class SessionManager(BaseModel):
         self,
         username: str,
         password: str,
-        challenge_type: Optional[str] = "email",
+        challenge_type: Optional[str] = "none",
         headers: Optional[CaseInsensitiveDictType] = None,
         proxies: Optional[Proxies] = None,
         **kwargs: Any,
@@ -118,8 +118,8 @@ class SessionManager(BaseModel):
 
         self.username: str = username
         self.password: str = password
-        if challenge_type not in ["email", "sms"]:
-            raise ValueError("challenge_type must be email or sms")
+        if challenge_type not in ["email", "sms", "none"]:
+            raise ValueError("challenge_type must be email, sms, or none")
         self.challenge_type: str = challenge_type
 
         self.device_token: str = kwargs.pop("device_token", str(uuid.uuid4()))
@@ -422,7 +422,6 @@ class SessionManager(BaseModel):
 
         """
         self.session.headers.pop("Authorization", None)
-
         oauth_payload = {
             "password": self.password,
             "username": self.username,
@@ -430,9 +429,19 @@ class SessionManager(BaseModel):
             "client_id": CLIENT_ID,
             "expires_in": EXPIRATION_TIME,
             "scope": "internal",
-            "device_token": self.device_token,
-            "challenge_type": self.challenge_type,
+            "device_token": "4cf700d5-933b-4aff-86b5-33ddd0e93cb4"
         }
+        if self.challenge_type != "none":
+            oauth_payload = {
+                "password": self.password,
+                "username": self.username,
+                "grant_type": "password",
+                "client_id": CLIENT_ID,
+                "expires_in": EXPIRATION_TIME,
+                "scope": "internal",
+                "device_token": self.device_token,
+                "challenge_type": self.challenge_type
+            }
 
         oauth = self.post(
             urls.OAUTH,

--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -1644,9 +1644,9 @@ class Robinhood(InstrumentManager, SessionManager):
 
         return open_orders
 
-        ##############################
-        # GET OPEN ORDER(S)
-        ##############################
+    ##############################
+    # GET CRYPTO ORDER(S)
+    ##############################
 
     def get_crypto_orders(self, order_id=None):
         """Returns the crypto order status.
@@ -1664,6 +1664,13 @@ class Robinhood(InstrumentManager, SessionManager):
                 orders_arr.append(order)
 
         return orders_arr
+
+    ##############################
+    #    CANCEL CRYPTO ORDER     #
+    ##############################
+
+    def cancel_crypto_order(self, cancel_url):  # noqa: C901
+        return self.post(cancel_url)
 
     ##############################
     #        CANCEL ORDER        #

--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -675,6 +675,18 @@ class Robinhood(InstrumentManager, SessionManager):
 
         return self.get(urls.build_orders(orderId))
 
+    def crypto_order_history(self, orderId=None):
+        """Wrapper for portfolios
+
+        Optional Args: add an order ID to retrieve information about a single order.
+
+        Returns:
+            (:obj:`dict`): JSON dict from getting orders
+
+        """
+
+        return self.get(urls.build_crypto_orders(orderId))
+
     def dividends(self):
         """Wrapper for portfolios
 
@@ -833,8 +845,33 @@ class Robinhood(InstrumentManager, SessionManager):
             (:obj:`requests.request`): result from `orders` post command
 
         """
-        return self.submit_crypto_buy_order(
+        return self.submit_crypto_order(
             side="buy",
+            currency_pair_id=currency_pair_id,
+            amount_in_usd=amount_in_usd
+        )
+
+    def place_market_crypto_sell_order(
+            self, currency_pair_id=None, amount_in_usd=None
+    ):
+        """Wrapper for placing crypto market buy orders
+
+        Notes:
+            If only one of the instrument_URL or symbol are passed as
+            arguments the other will be looked up automatically.
+
+        Args:
+            currency_pair_id (str): The RH URL of the instrument
+            price (str): The ticker symbol of the instrument
+            time_in_force (str): 'GFD' or 'GTC' (day or until cancelled)
+            quantity (int): Number of shares to buy
+
+        Returns:
+            (:obj:`requests.request`): result from `orders` post command
+
+        """
+        return self.submit_crypto_order(
+            side="sell",
             currency_pair_id=currency_pair_id,
             amount_in_usd=amount_in_usd
         )
@@ -1380,7 +1417,7 @@ class Robinhood(InstrumentManager, SessionManager):
             except:  # noqa: E722
                 print(ex)
 
-    def submit_crypto_buy_order(
+    def submit_crypto_order(
         self,
         currency_pair_id=None,
         amount_in_usd=None,
@@ -1606,6 +1643,27 @@ class Robinhood(InstrumentManager, SessionManager):
                 open_orders.append(order)
 
         return open_orders
+
+        ##############################
+        # GET OPEN ORDER(S)
+        ##############################
+
+    def get_crypto_orders(self, order_id=None):
+        """Returns the crypto order status.
+
+        TODO: Is there a way to get these from the API endpoint without stepping through
+            order history?
+        """
+
+        orders_arr = []
+        orders = self.crypto_order_history(orderId=order_id)
+        if order_id is not None:
+            orders_arr.append(orders)
+        else:
+            for order in orders["results"]:
+                orders_arr.append(order)
+
+        return orders_arr
 
     ##############################
     #        CANCEL ORDER        #

--- a/pyrh/urls.py
+++ b/pyrh/urls.py
@@ -119,7 +119,7 @@ def build_orders(order_id: str = None) -> URL:
 
     """
     if order_id is not None:
-        return ORDERS_BASE / f"/{order_id}/"
+        return ORDERS_BASE / f"{order_id}/"
     else:
         return ORDERS_BASE
 
@@ -135,7 +135,7 @@ def build_crypto_orders(order_id: str = None) -> URL:
 
     """
     if order_id is not None:
-        return NUMMIS_ORDERS_BASE / f"/{order_id}/"
+        return NUMMIS_ORDERS_BASE / f"{order_id}/"
     else:
         return NUMMIS_ORDERS_BASE
 

--- a/pyrh/urls.py
+++ b/pyrh/urls.py
@@ -9,9 +9,12 @@ from yarl import URL
 
 # Base
 API_BASE = URL("https://api.robinhood.com")
+# Nummus Base
+NUMMIS_API_BASE = URL("https://nummus.robinhood.com")
 
 # General
 ACCOUNTS = API_BASE / "accounts/"
+NUMMIS_ACCOUNTS = NUMMIS_API_BASE / "accounts/"
 ACH_BASE = API_BASE / "ach/"  # not implemented
 APPLICATIONS = API_BASE / "applications/"  # not implemented
 DIVIDENDS = API_BASE / "dividends/"
@@ -25,6 +28,7 @@ MARKET_DATA_BASE = API_BASE / "marketdata/"
 NEWS_BASE = API_BASE / "midlands/news/"
 NOTIFICATIONS = API_BASE / "notifications/"  # not implemented
 ORDERS_BASE = API_BASE / "orders/"
+NUMMIS_ORDERS_BASE = NUMMIS_API_BASE / "orders/"
 PORTFOLIOS = API_BASE / "portfolios/"
 POSITIONS = API_BASE / "positions/"
 TAGS_BASE = API_BASE / "midlands/tags/tag/"
@@ -42,6 +46,7 @@ INVESTMENT_PROFILE = USER / "investment_profile/"
 # Quotes
 QUOTES = API_BASE / "quotes/"
 HISTORICALS = QUOTES / "historicals/"
+CRYPTO = MARKET_DATA_BASE / "forex/quotes/"
 
 # Auth
 OAUTH_BASE: URL = API_BASE / "oauth2/"
@@ -117,6 +122,22 @@ def build_orders(order_id: str = None) -> URL:
         return ORDERS_BASE / f"/{order_id}/"
     else:
         return ORDERS_BASE
+
+
+def build_crypto_orders(order_id: str = None) -> URL:
+    """Build endpoint to place orders."
+
+    Args:
+        order_id: the id of the order
+
+    Returns:
+        A constructed URL for a particular order or the base URL for all orders.
+
+    """
+    if order_id is not None:
+        return NUMMIS_ORDERS_BASE / f"/{order_id}/"
+    else:
+        return NUMMIS_ORDERS_BASE
 
 
 def build_news(stock: str) -> URL:


### PR DESCRIPTION
I'm mainly creating this PR to get some feedback and opinions on some changes I have made. This PR should not be merged in its current state. 

The main two features I added is the ability to not pass in a challenge_type so you can authenticate with just an email/password.

The next big thing is adding cryptocurrency trading to it. Provide as much feedback as you would like.