### PR TITLE
Fix bug in cancel_order due to wrong concatenation syntax

### DIFF
--- a/newsfragments/296.bugfix
+++ b/newsfragments/296.bugfix
@@ -1,0 +1,1 @@
+Fix bug in cancel_order due to wrong concatenation syntax.

--- a/pyrh/robinhood.py
+++ b/pyrh/robinhood.py
@@ -1444,7 +1444,7 @@ class Robinhood(InstrumentManager, SessionManager):
         """
         if isinstance(order_id, str):
             try:
-                order = self.get(urls.build_orders() + order_id)
+                order = self.get(urls.build_orders(order_id))
             except (requests.exceptions.HTTPError) as err_msg:
                 raise ValueError(
                     "Failed to get Order for ID: "
@@ -1475,7 +1475,7 @@ class Robinhood(InstrumentManager, SessionManager):
         elif isinstance(order_id, dict):
             order_id = order_id["id"]
             try:
-                order = self.get(urls.build_orders() + order_id)
+                order = self.get(urls.build_orders(order_id))
             except (requests.exceptions.HTTPError) as err_msg:
                 raise ValueError(
                     "Failed to get Order for ID: "

--- a/pyrh/urls.py
+++ b/pyrh/urls.py
@@ -113,7 +113,7 @@ def build_orders(order_id: Optional[str] = None) -> URL:
 
     """
     if order_id is not None:
-        return ORDERS_BASE / f"/{order_id}/"
+        return ORDERS_BASE / f"{order_id}/"
     else:
         return ORDERS_BASE
 


### PR DESCRIPTION
#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
- [x] I've added a news fragment of my changes with the name,
  "{ISSUE_NUM}.{feature|bugfix|doc|removal|misc}""

# Related Issue

Fixes #280, fixes #281 

# Description

Cancel order throws an error as follows:
```
----> 1 cancel_order = rh.cancel_order(order_id)

File ~/.local/lib/python3.8/site-packages/pyrh/robinhood.py:1474, in Robinhood.cancel_order(self, order_id)
   1472 if isinstance(order_id, str):
   1473     try:
-> 1474         order = self.get(urls.build_orders() + order_id)
   1475     except (requests.exceptions.HTTPError) as err_msg:
   1476         raise ValueError(
   1477             "Failed to get Order for ID: "
   1478             + order_id
   1479             + "\n Error message: "
   1480             + repr(err_msg)
   1481         )

TypeError: unsupported operand type(s) for +: 'URL' and 'str'
```
# Verification

With the new changes, an order can be canceled successfully.