### PR TITLE
Move unwanted print statement to `input`

### DIFF
--- a/pyrh/models/sessionmanager.py
+++ b/pyrh/models/sessionmanager.py
@@ -388,7 +388,7 @@ class SessionManager(BaseModel):
         if self.mfa != "":
             mfa_code = pyotp.TOTP(self.mfa).now()
         else:
-            mfa_code = input("Input mfa code:")
+            mfa_code = input("Input mfa code: ")
         oauth_payload["mfa_code"] = mfa_code
         oauth, res = self.post(
             urls.OAUTH,

--- a/pyrh/models/sessionmanager.py
+++ b/pyrh/models/sessionmanager.py
@@ -385,11 +385,10 @@ class SessionManager(BaseModel):
                 number of attempts.
 
         """
-        print("Input mfa code:")
         if self.mfa != "":
             mfa_code = pyotp.TOTP(self.mfa).now()
         else:
-            mfa_code = input()
+            mfa_code = input("Input mfa code:")
         oauth_payload["mfa_code"] = mfa_code
         oauth, res = self.post(
             urls.OAUTH,


### PR DESCRIPTION
<!--
Thanks you for taking the time to submit a pull request! Please take a look at some
guidelines before submitting a pull request:
https://github.com/robinhood-unofficial/pyrh/blob/master/doc/developers.rst

Below are some gentle reminder about common mistakes before PR submission. Please make sure that you tick
all *appropriate* boxes.
-->

#### Checklist
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
- [ ] I've added a news fragment of my changes with the name,
  "{ISSUE_NUM}.{feature|bugfix|doc|removal|misc}""


# Related Issue
<!--
Example: Fixes #7. See also #35.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

# Description
<!--
Please add a narrative description of your the changes made and the rationale behind
them. If making an enhancement include the motivation and use cases addressed.
-->

> Moved the "Input mfa code:" within `input` statement

**Reason:**
There is no reason for the print statement to be stand-alone, as it will eventually be printed in the console for standard input in python

I'd also prefer pyrh using logger instead of print statements all over, but I'm not sure how you feel changing it. If it is a 👍🏻 , I can create a follow up PR for that as well. It doesn't need to be a static logger, pyrh can use a default logger and still give an option to users to bring their own formatted logger.
